### PR TITLE
Fix for deleting vertex with spatial index on geometry collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ test-output/*
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/

--- a/src/main/java/com/orientechnologies/spatial/shape/OShapeFactory.java
+++ b/src/main/java/com/orientechnologies/spatial/shape/OShapeFactory.java
@@ -189,7 +189,18 @@ public class OShapeFactory extends OComplexShapeBuilder {
   }
 
   public Geometry toGeometry(Shape shape) {
-    return SPATIAL_CONTEXT.getGeometryFrom(shape);
+	if(shape instanceof ShapeCollection){
+		ShapeCollection<Shape> shapes = (ShapeCollection<Shape>) shape;
+		Geometry[] geometries = new Geometry[shapes.size()];
+	    int i = 0;
+	    for (Shape shapeItem : shapes) {
+	      geometries[i] = SPATIAL_CONTEXT.getGeometryFrom(shapeItem);
+	      i++;
+	    }
+	    return GEOMETRY_FACTORY.createGeometryCollection(geometries);
+	} else {
+		return SPATIAL_CONTEXT.getGeometryFrom(shape);
+	}
   }
 
   public ODocument toDoc(Geometry geometry) {
@@ -197,6 +208,16 @@ public class OShapeFactory extends OComplexShapeBuilder {
       com.vividsolutions.jts.geom.Point point = (com.vividsolutions.jts.geom.Point) geometry;
       Point point1 = context().makePoint(point.getX(), point.getY());
       return toDoc(point1);
+    }
+    if(geometry instanceof com.vividsolutions.jts.geom.GeometryCollection){
+    	com.vividsolutions.jts.geom.GeometryCollection gc = (com.vividsolutions.jts.geom.GeometryCollection) geometry;
+    	List<Shape> shapes = new ArrayList<Shape>();
+    	for(int i = 0; i < gc.getNumGeometries(); i++){
+    		Geometry geo = gc.getGeometryN(i);
+    		Shape shape = SPATIAL_CONTEXT.makeShape(geo);
+    		shapes.add(shape);
+    	}
+    	return toDoc(new ShapeCollection<Shape>(shapes, SPATIAL_CONTEXT));
     }
     return toDoc(SPATIAL_CONTEXT.makeShape(geometry));
   }

--- a/src/main/java/com/orientechnologies/spatial/shape/OShapeFactory.java
+++ b/src/main/java/com/orientechnologies/spatial/shape/OShapeFactory.java
@@ -29,6 +29,8 @@ import org.locationtech.spatial4j.shape.jts.JtsGeometry;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 public class OShapeFactory extends OComplexShapeBuilder {
 

--- a/src/test/java/com/orientechnologies/spatial/GeometryCollectionTest.java
+++ b/src/test/java/com/orientechnologies/spatial/GeometryCollectionTest.java
@@ -1,0 +1,35 @@
+package com.orientechnologies.spatial;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.OCommandSQL;
+
+public class GeometryCollectionTest extends BaseSpatialLuceneTest {
+
+	@Test
+	public void testDeleteVerticesWithGeometryCollection() {
+		db.command(new OCommandSQL("CREATE CLASS Test extends V")).execute();
+		db.command(new OCommandSQL("CREATE PROPERTY Test.name STRING")).execute();
+		db.command(new OCommandSQL("CREATE PROPERTY Test.geometry EMBEDDED OGeometryCollection")).execute();
+
+		db.command(new OCommandSQL("CREATE INDEX Test.geometry ON Test(geometry) SPATIAL ENGINE LUCENE")).execute();
+
+		db.command(new OCommandSQL(
+				"insert into Test content {'name': 'loc1', 'geometry': {'@type':'d','@class':'OGeometryCollection','geometries':[{'@type':'d','@class':'OPolygon','coordinates':[[[0,0],[0,10],[10,10],[10,0],[0,0]]]}]}}"))
+				.execute();
+		db.command(new OCommandSQL(
+				"insert into Test content {'name': 'loc2', 'geometry': {'@type':'d','@class':'OGeometryCollection','geometries':[{'@type':'d','@class':'OPolygon','coordinates':[[[0,0],[0,20],[20,20],[20,0],[0,0]]]}]}}"))
+				.execute();
+
+		List<ODocument> qResult = db
+				.command(new OCommandSQL(
+						"select * from Test where ST_WITHIN(geometry,'POLYGON ((0 0, 15 0, 15 15, 0 15, 0 0))') = true"))
+				.execute();
+
+		db.command(new OCommandSQL("DELETE VERTEX Test")).execute();
+	}
+
+}

--- a/src/test/java/com/orientechnologies/spatial/GeometryCollectionTest.java
+++ b/src/test/java/com/orientechnologies/spatial/GeometryCollectionTest.java
@@ -3,6 +3,7 @@ package com.orientechnologies.spatial;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.Assert;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
@@ -28,8 +29,12 @@ public class GeometryCollectionTest extends BaseSpatialLuceneTest {
 				.command(new OCommandSQL(
 						"select * from Test where ST_WITHIN(geometry,'POLYGON ((0 0, 15 0, 15 15, 0 15, 0 0))') = true"))
 				.execute();
+		Assert.assertEquals(1, qResult.size());
 
 		db.command(new OCommandSQL("DELETE VERTEX Test")).execute();
+		
+		List<ODocument> qResult2 = db.command(new OCommandSQL("select * from Test")).execute();
+		Assert.assertEquals(0, qResult2.size());
 	}
 
 }


### PR DESCRIPTION
I found an issue when deleting vertex with spatial index on geometry collection. The plugin was throwing the following exception attached. Issue was 
[odb-spatial-issue-trace.txt](https://github.com/orientechnologies/orientdb-spatial/files/701749/odb-spatial-issue-trace.txt)

Issue was with getting JTS geometry from ShapeCollection which is not supported. I have made the fix and added a UT to verify it. The UT suite is running fine. Please include the fix as i need it asap.
