### PR TITLE
Fix for using Spatial index on Geometry collection in select queries

### DIFF
--- a/src/main/java/com/orientechnologies/spatial/shape/OGeometryCollectionShapeBuilder.java
+++ b/src/main/java/com/orientechnologies/spatial/shape/OGeometryCollectionShapeBuilder.java
@@ -28,6 +28,7 @@ import org.locationtech.spatial4j.shape.ShapeCollection;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by Enrico Risa on 17/08/15.
@@ -48,6 +49,13 @@ public class OGeometryCollectionShapeBuilder extends OComplexShapeBuilder<ShapeC
   @Override
   public OShapeType getType() {
     return OShapeType.GEOMETRYCOLLECTION;
+  }
+  
+  @Override
+  public ShapeCollection<Shape> fromMapGeoJson(Map<String, Object> geoJsonMap) {
+    ODocument doc = new ODocument(getName());
+    doc.field("geometries", geoJsonMap.get("geometries"));
+    return fromDoc(doc);
   }
 
   @Override

--- a/src/test/java/com/orientechnologies/spatial/functions/LuceneSpatialContainsTest.java
+++ b/src/test/java/com/orientechnologies/spatial/functions/LuceneSpatialContainsTest.java
@@ -81,5 +81,38 @@ public class LuceneSpatialContainsTest {
       graph.drop();
     }
   }
+  
+  @Test
+  public void testContainsIndex_GeometryCollection() {
+
+    OrientGraphNoTx graph = new OrientGraphNoTx("memory:functionsTestWithIndex");
+    try {
+      ODatabaseDocumentTx db = graph.getRawGraph();
+
+      db.command(new OCommandSQL("create class Test extends v")).execute();
+		db.command(new OCommandSQL("create property Test.geometry EMBEDDED OGeometryCollection")).execute();
+
+		db.command(new OCommandSQL(
+				"insert into Test set geometry = {'@type':'d','@class':'OGeometryCollection','geometries':[{'@type':'d','@class':'OPolygon','coordinates':[[[0,0],[10,0],[10,10],[0,10],[0,0]]]}]}"))
+				.execute();
+		db.command(new OCommandSQL(
+				"insert into Test set geometry = {'@type':'d','@class':'OGeometryCollection','geometries':[{'@type':'d','@class':'OPolygon','coordinates':[[[11,11],[21,11],[21,21],[11,21],[11,11]]]}]}"))
+				.execute();
+
+		db.command(new OCommandSQL("create index Test.geometry on Test (geometry) SPATIAL engine lucene"))
+				.execute();
+		
+		String testGeometry = "{'@type':'d','@class':'OGeometryCollection','geometries':[{'@type':'d','@class':'OPolygon','coordinates':[[[1,1],[2,1],[2,2],[1,2],[1,1]]]}]}";
+		List<ODocument> execute = db
+				.command(new OCommandSQL(
+						"SELECT from Test where ST_Contains(geometry, " + testGeometry + ") = true"))
+				.execute();
+
+		Assert.assertEquals(execute.size(), 1);
+
+    } finally {
+      graph.drop();
+    }
+  }
 
 }


### PR DESCRIPTION
Select query using Spatial functions like ST_Contains, ST_Within etc. on an indexed GeometryCollection fails. The following exception occurs.
[ODB-spatial-NPE.txt](https://github.com/orientechnologies/orientdb-spatial/files/707574/ODB-spatial-NPE.txt)

This is because the "geometries" property of GeometryCollection is not set properly. I have fixed the issue and added a UT to test it. Please merge the changes and release it in 2.2.15. I need the fix asap.